### PR TITLE
Update AboutUs and README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= Address Book (Level 4)
+= UniCity
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 

--- a/docs/AboutUs.adoc
+++ b/docs/AboutUs.adoc
@@ -4,53 +4,43 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :imagesDir: images
 :stylesDir: stylesheets
 
-AddressBook - Level 4 was developed by the https://se-edu.github.io/docs/Team.html[se-edu] team. +
-The dummy content given below serves as a placeholder to be used by future forks of the project. +
-{empty} +
+UniCity was developed by the https://github.com/CS2103AUG2017-W13-B1 team. +
+
 We are a team based in the http://www.comp.nus.edu.sg[School of Computing, National University of Singapore].
 
 == Project Team
 
-=== John Doe
+=== Vivek
 image::damithc.jpg[width="150", align="left"]
-{empty}[http://www.comp.nus.edu.sg/~damithch[homepage]] [https://github.com/damithc[github]] [<<johndoe#, portfolio>>]
+{empty}[https://github.com/vivekscl[github]] [<<vivek#, portfolio>>]
 
 Role: Project Advisor
 
 '''
 
-=== John Roe
+=== Tao Jiashu
 image::lejolly.jpg[width="150", align="left"]
-{empty}[http://github.com/lejolly[github]] [<<johndoe#, portfolio>>]
+{empty}[http://github.com/taojiashu[github]] [<<jiashu#, portfolio>>]
 
 Role: Team Lead +
 Responsibilities: UI
 
 '''
 
-=== Johnny Doe
+=== Jacob
 image::yijinl.jpg[width="150", align="left"]
-{empty}[http://github.com/yijinl[github]] [<<johndoe#, portfolio>>]
+{empty}[http://github.com/jacoblipech[github]] [<<johndoe#, portfolio>>]
 
 Role: Developer +
 Responsibilities: Data
 
 '''
 
-=== Johnny Roe
+=== Lee Ying Zheng
 image::m133225.jpg[width="150", align="left"]
 {empty}[http://github.com/m133225[github]] [<<johndoe#, portfolio>>]
 
 Role: Developer +
 Responsibilities: Dev Ops + Threading
-
-'''
-
-=== Benson Meier
-image::yl_coder.jpg[width="150", align="left"]
-{empty}[http://github.com/yl-coder[github]] [<<johndoe#, portfolio>>]
-
-Role: Developer +
-Responsibilities: UI
 
 '''


### PR DESCRIPTION
Changed Addressbook name in README.adoc to UniCity. Updated the AboutUs.adoc to include our names and links to our github accounts.
To Do:
1. Create each of our own portfolios and provide links to it in AboutUs.adoc
2. Upload personal photo and include it in AboutUs.adoc (how to do this ah)
3. Divide workload and specify responsibilities in AboutUs.adoc